### PR TITLE
remove members queries which fetch all club members at once

### DIFF
--- a/queries.py
+++ b/queries.py
@@ -142,7 +142,6 @@ async def members(clubInput: SimpleClubInput, info: Info) -> List[MemberType]:
     Returns:
         (List[MemberType]): Contains a list of members.
     """
-
     user = info.context.user
     if user is None:
         role = "public"
@@ -150,36 +149,51 @@ async def members(clubInput: SimpleClubInput, info: Info) -> List[MemberType]:
         role = user["role"]
 
     club_input = jsonable_encoder(clubInput)
-
-    results = [
-        doc
-        async for doc in membersdb.find(
-            {"cid": club_input["cid"]}, {"_id": 0}
-        )
+    
+    role_conditions = [{"$ne": ["$$role.deleted", True]}]
+    
+    # for public users, only show approved roles
+    if role == "public":
+        role_conditions.append({"$eq": ["$$role.approved", True]})
+    # for club users, only show approved roles unless they're viewing their own club
+    elif role == "club" and user["uid"] != club_input["cid"]:
+        role_conditions.append({"$eq": ["$$role.approved", True]})
+    # for CC and own club, show both approved and pending (approved=false) roles
+    
+    pipeline = [
+        {
+            "$match": {
+                "cid": club_input["cid"]
+            }
+        },
+        {
+            "$addFields": {
+                "roles": {
+                    "$filter": {
+                        "input": "$roles",
+                        "as": "role",
+                        "cond": {
+                            "$and": role_conditions
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$match": {
+                "roles.0": {"$exists": True}
+            }
+        },
+        {
+            "$project": {"_id": 0}
+        }
     ]
-
+    
+    cursor = await membersdb.aggregate(pipeline)
     members = []
-    for result in results:
-        roles = result["roles"]
-        roles_result = []
-
-        for i in roles:
-            if i["deleted"] is True:
-                continue
-            if not (
-                role in ["cc"]
-                or (role in ["club"] and user["uid"] == club_input["cid"])
-            ):
-                if i["approved"] is False:
-                    continue
-            roles_result.append(i)
-
-        if len(roles_result) > 0:
-            result["roles"] = roles_result
-            members.append(
-                MemberType.from_pydantic(Member.model_validate(result))
-            )
-
+    async for doc in cursor:
+        members.append(MemberType.from_pydantic(Member.model_validate(doc)))
+    
     return members
 
 
@@ -200,8 +214,7 @@ async def currentMembers(
 
     Raises:
         Exception: Not Authenticated
-    """  # noqa: E501
-
+    """
     user = info.context.user
     if user is None:
         role = "public"
@@ -209,32 +222,45 @@ async def currentMembers(
         role = user["role"]
 
     club_input = jsonable_encoder(clubInput)
-
-    results = [
-        doc
-        async for doc in membersdb.find(
-            {"cid": club_input["cid"]}, {"_id": 0}
-        )
+    
+    pipeline = [
+        {
+            "$match": {
+                "cid": club_input["cid"]
+            }
+        },
+        {
+            "$addFields": {
+                "roles": {
+                    "$filter": {
+                        "input": "$roles",
+                        "as": "role",
+                        "cond": {
+                            "$and": [
+                                {"$ne": ["$$role.deleted", True]},
+                                {"$eq": ["$$role.approved", True]},
+                                {"$eq": ["$$role.end_year", None]}
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$match": {
+                "roles.0": {"$exists": True}
+            }
+        },
+        {
+            "$project": {"_id": 0}
+        }
     ]
-
+    
+    cursor = await membersdb.aggregate(pipeline)
     members = []
-    for result in results:
-        roles = result["roles"]
-        roles_result = []
-
-        for i in roles:
-            if i["deleted"] or i["end_year"] is not None:
-                continue
-            if i["approved"] is False:
-                continue
-            roles_result.append(i)
-
-        if len(roles_result) > 0:
-            result["roles"] = roles_result
-            members.append(
-                MemberType.from_pydantic(Member.model_validate(result))
-            )
-
+    async for doc in cursor:
+        members.append(MemberType.from_pydantic(Member.model_validate(doc)))
+    
     return members
 
 
@@ -243,41 +269,50 @@ async def pendingMembers(info: Info) -> List[MemberType]:
     """
     Returns the pending members of all clubs with their non-deleted,
     pending roles for CC.
-
     Args:
         info (Info): Contains the logged in user's details.
-
     Returns:
         (List[MemberType]): Contains a list of members.
-
     Raises:
         Exception: Not Authenticated
     """
-
     user = info.context.user
     if user is None or user["role"] not in ["cc"]:
         raise Exception("Not Authenticated")
+    pipeline = [
+        {
+            "$addFields": {
+                "roles": {
+                    "$filter": {
+                        "input": "$roles",
+                        "as": "role",
+                        "cond": {
+                            "$and": [
+                                {"$ne": ["$$role.deleted", True]},
+                                {"$ne": ["$$role.approved", True]},
+                                {"$ne": ["$$role.rejected", True]}
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$match": {
+                "roles.0": {"$exists": True}
+            }
+        },
+        {
+            "$project": {"_id": 0}
+        }
+    ]
 
-    results = [doc async for doc in membersdb.find({}, {"_id": 0})]
-
+    cursor = await membersdb.aggregate(pipeline)
     members = []
-    for result in results:
-        roles = result["roles"]
-        roles_result = []
-
-        for i in roles:
-            if i["deleted"] or i["approved"] or i["rejected"]:
-                continue
-            roles_result.append(i)
-
-        if len(roles_result) > 0:
-            result["roles"] = roles_result
-            members.append(
-                MemberType.from_pydantic(Member.model_validate(result))
-            )
-
+    async for doc in cursor:
+        members.append(MemberType.from_pydantic(Member.model_validate(doc)))
+    
     return members
-
 
 @strawberry.field
 async def downloadMembersData(

--- a/queries.py
+++ b/queries.py
@@ -282,7 +282,7 @@ async def pendingMembers(info: Info) -> List[MemberType]:
                         "cond": {
                             "$and": [
                                 {"$ne": ["$$role.deleted", True]},
-                                {"$ne": ["$$role.approved", True]},
+                                {"$eq": ["$$role.approved", False]},
                                 {"$ne": ["$$role.rejected", True]}
                             ]
                         }

--- a/queries.py
+++ b/queries.py
@@ -151,15 +151,12 @@ async def members(clubInput: SimpleClubInput, info: Info) -> List[MemberType]:
 
     club_input = jsonable_encoder(clubInput)
 
-    if role not in ["cc"] or club_input["cid"] != "clubs":
-        results = [
-            doc
-            async for doc in membersdb.find(
-                {"cid": club_input["cid"]}, {"_id": 0}
-            )
-        ]
-    else:
-        results = [doc async for doc in membersdb.find({}, {"_id": 0})]
+    results = [
+        doc
+        async for doc in membersdb.find(
+            {"cid": club_input["cid"]}, {"_id": 0}
+        )
+    ]
 
     members = []
     for result in results:
@@ -213,17 +210,12 @@ async def currentMembers(
 
     club_input = jsonable_encoder(clubInput)
 
-    if club_input["cid"] == "clubs":
-        if role != "cc":
-            raise Exception("Not Authenticated")
-        results = [doc async for doc in membersdb.find({}, {"_id": 0})]
-    else:
-        results = [
-            doc
-            async for doc in membersdb.find(
-                {"cid": club_input["cid"]}, {"_id": 0}
-            )
-        ]
+    results = [
+        doc
+        async for doc in membersdb.find(
+            {"cid": club_input["cid"]}, {"_id": 0}
+        )
+    ]
 
     members = []
     for result in results:

--- a/queries.py
+++ b/queries.py
@@ -189,7 +189,7 @@ async def members(clubInput: SimpleClubInput, info: Info) -> List[MemberType]:
         }
     ]
     
-    members_cursor = membersdb.aggregate(pipeline)
+    members_cursor = await membersdb.aggregate(pipeline)
     members = [
         MemberType.from_pydantic(Member.model_validate(doc))
         async for doc in members_cursor
@@ -250,7 +250,7 @@ async def currentMembers(
         }
     ]
     
-    members_cursor = membersdb.aggregate(pipeline)
+    members_cursor = await membersdb.aggregate(pipeline)
     return [
         MemberType.from_pydantic(Member.model_validate(doc))
         async for doc in members_cursor
@@ -300,7 +300,7 @@ async def pendingMembers(info: Info) -> List[MemberType]:
         }
     ]
 
-    members_cursor = membersdb.aggregate(pipeline)
+    members_cursor = await membersdb.aggregate(pipeline)
     return [
         MemberType.from_pydantic(Member.model_validate(doc))
         async for doc in members_cursor


### PR DESCRIPTION
## Changes

- Change members queries to remove all club related fetches.
- Now there is only simple way to fetch, which is to specify the cid.

## Parent PR

https://github.com/Clubs-Council-IIITH/web/pull/163